### PR TITLE
Implement Fight search by source destination dropdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CloudTrip CI
 on:
   pull_request:
   push:
-    branches: [ main, feature/flight-search-passenger-count ]
+    branches: [ main, ui/add-source-destination-dropdown ]
 
 jobs:
   lint:

--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -15,6 +15,11 @@ html, body {
   margin: 0;
   padding: 0;
   overflow-x: hidden;
+  box-sizing: border-box; 
+}
+
+*, *::before, *::after {
+  box-sizing: inherit;
 }
 
 .page-container {

--- a/app/views/flights/index.html.erb
+++ b/app/views/flights/index.html.erb
@@ -3,15 +3,15 @@
   <head>
     <style>
       .container {
-        margin: 2rem;
         background-color: var(--app-bg);
         border-radius: 0.75rem;
         display: flex;
         flex-direction: column;
         justify-content: flex-start;
         align-items: center;
-        padding: 1.5rem;
         font-family: var(--font-family-inter);
+        margin-top: 2rem;
+        padding: 1.5rem 1.5rem;
       }
 
       .sub-header {
@@ -26,6 +26,7 @@
         padding: 2rem;
         max-width: 600px;
         border-radius: 0.5rem;
+        box-sizing: border-box;
       }
 
       .form-group {
@@ -140,13 +141,26 @@
         <div class="form-group half">
           <div>
             <%= f.label :source, "Origin :" %>
-            <%= f.text_field :source, placeholder: "Bangalore" %>
+            <%= f.text_field :source, id: "source-input", list: "source-list" %>
           </div>
           <div>
             <%= f.label :destination, "Destination :" %>
-            <%= f.text_field :destination, placeholder: "London" %>
+            <%= f.text_field :destination, id: "destination-input", list: "destination-list" %>
           </div>
         </div>
+        
+        <datalist id="source-list">
+        <% @cities.each do |city| %>
+          <option value="<%= city %>">
+        <% end %>
+      </datalist>
+
+    <datalist id="destination-list">
+      <% (@destination_options || @cities).each do |city| %>
+        <option value="<%= city %>">
+      <% end %>
+    </datalist>
+            
 
         <div class="form-group half">
           <div>
@@ -163,7 +177,7 @@
       <% end %>
 
       <% if flash[:alert] %>
-        <p style="color: red"><%= flash[:alert] %></p>
+        <p style="color: red; font-weight: bold;"><%= flash[:alert] %></p>
       <% end %>
 
       <% if @matching_flights.present? %>

--- a/spec/controllers/flight_controller_spec.rb
+++ b/spec/controllers/flight_controller_spec.rb
@@ -78,5 +78,21 @@ RSpec.describe "Flights", type: :request do
       expect(response.body).to include("F101")
     end
   end
+
+  context "when origin and destination are the same" do
+      it "shows an error and no flights" do
+        post "/flights/search", params: {
+          source: "Chennai",
+          destination: "Chennai",
+          date: "2025-07-04",
+          passengers: 1
+        }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Origin and Destination must be different.")
+        expect(response.body).not_to include("F101")
+        expect(response.body).not_to include("F103")
+      end
+    end
   end
 end


### PR DESCRIPTION
**This PR adds a test case to validate that users cannot search for flights with the same origin and destination.**

- Add a check for source and destination. 

- Modify styling in custom file. 

- Apply lint formatting. 

✅ Tests: 

- A request spec that ensures: When origin and destination are the same (e.g., "Chennai" to "Chennai")

- The system returns a flash message: "Origin and Destination must be different."