### PR TITLE
Exclude Flights with Past Departure Times on Current Date

### DIFF
--- a/app/controllers/flights_controller.rb
+++ b/app/controllers/flights_controller.rb
@@ -48,10 +48,21 @@ class FlightsController < ApplicationController
               [ flight[:economy_seats], 1.0 ]
         end
 
+        time_condition = true
+
+        if Date.parse(date) == Time.zone.today
+          now = Time.zone.now
+          flight_datetime_str = "#{flight[:departure_date]} #{flight[:departure_time]}"
+          flight_time = Time.strptime(flight_datetime_str, "%Y-%m-%d %I:%M %p")
+          time_condition = flight_time > now
+        end
+
       flight[:source].casecmp?(source) &&
       flight[:destination].casecmp?(destination) &&
       flight[:departure_date] == date &&
-      seats_available >= passengers
+      seats_available >= passengers &&
+      time_condition
+      
     end.map do |flight|
       seat_key = "#{class_type}_seats".to_sym
       available_seats = flight[seat_key]

--- a/app/controllers/flights_controller.rb
+++ b/app/controllers/flights_controller.rb
@@ -62,7 +62,6 @@ class FlightsController < ApplicationController
       flight[:departure_date] == date &&
       seats_available >= passengers &&
       time_condition
-      
     end.map do |flight|
       seat_key = "#{class_type}_seats".to_sym
       available_seats = flight[seat_key]

--- a/spec/controllers/flight_controller_spec.rb
+++ b/spec/controllers/flight_controller_spec.rb
@@ -175,9 +175,9 @@ DATA
       end
     end
     context "when searching flights for today with past and future times" do
-      let(:today) { Date.today.strftime("%Y-%m-%d") }
-      let(:past_time) { (Time.now - 1.hour).strftime("%I:%M %p") }
-      let(:future_time) { (Time.now + 1.hour).strftime("%I:%M %p") }
+      let(:today) { Time.zone.today.strftime("%Y-%m-%d") }
+      let(:past_time) { (1.hour.ago).strftime("%I:%M %p") }
+      let(:future_time) { (1.hour.from_now).strftime("%I:%M %p") }
 
       before do
         File.write(data_path, <<~DATA)


### PR DESCRIPTION
### What does this PR do?

- Updates the flight search logic to exclude flights whose departure time has already passed when searching for flights departing today.

### Details

- For flights where `departure_date` matches today's date:
  - Parses the flight’s departure time and combines it with the departure date.
  - Compares this timestamp with the current time.
  - Filters out flights if their departure time is in the past.
- Ensures that only valid, upcoming flights are shown to users for same-day searches.

### Tests:
- All tests cases have been passed.