### PR TITLE
Add API Endpoint and Service for Loading Cities

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem "kamal", require: false
 
 # Add HTTP asset caching/compression and X-Sendfile acceleration to Puma [https://github.com/basecamp/thruster/]
 gem "thruster", require: false
+gem "rack-cors"
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -224,6 +224,9 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.1.16)
+    rack-cors (3.0.0)
+      logger
+      rack (>= 3.0.14)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -397,6 +400,7 @@ DEPENDENCIES
   propshaft
   pry-rails
   puma (>= 5.0)
+  rack-cors
   rails (~> 8.0.2)
   rspec-rails
   rubocop

--- a/app/controllers/api/flights_controller.rb
+++ b/app/controllers/api/flights_controller.rb
@@ -1,0 +1,8 @@
+module Api
+  class FlightsController < ApplicationController
+    def cities
+      cities = FlightDataService.load_unique_cities
+      render json: { cities: cities }
+    end
+  end
+end

--- a/app/services/flight_data_service.rb
+++ b/app/services/flight_data_service.rb
@@ -1,0 +1,9 @@
+class FlightDataService
+  DATA_PATH = Rails.configuration.flight_data_file
+  def self.load_unique_cities
+    File.readlines(DATA_PATH).map do |line|
+      fields = line.strip.split(",")
+      [ fields[1], fields[2] ]
+    end.flatten.uniq.sort
+  end
+end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,0 +1,10 @@
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins "http://localhost:5173"
+
+    resource "/api/*",
+      headers: :any,
+      methods: [ :get, :post, :options ],
+      credentials: false
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,4 @@
 Rails.application.routes.draw do
-  get "flights/index"
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
 
   root "flights#index"
@@ -11,10 +6,7 @@ Rails.application.routes.draw do
   get "flights/search", to: "flights#search"
   post "flights/book", to: "flights#book"
 
-  # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)
-  # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
-  # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
-
-  # Defines the root path route ("/")
-  # root "posts#index"
+  namespace :api do
+    get "cities", to: "flights#cities"
+  end
 end

--- a/spec/requests/flights_spec.rb
+++ b/spec/requests/flights_spec.rb
@@ -12,14 +12,6 @@ RSpec.describe "Flights", type: :request do
     DATA
   end
 
-  describe "GET /flights/index" do
-    it "returns http success" do
-      get "/flights/index"
-      expect(response).to have_http_status(:success)
-      expect(response.body).to include("Search")
-    end
-  end
-
   describe "GET /flights/search" do
     it "renders the index page" do
       get "/flights/search", params: { source: "Bangalore", destination: "London" }
@@ -47,6 +39,18 @@ RSpec.describe "Flights", type: :request do
       }
       expect(response).to have_http_status(:success)
       expect(response.body).to include("No Flights Available")
+    end
+  end
+end
+
+RSpec.describe "Api::Flights", type: :request do
+  describe "GET /api/cities" do
+    it "returns cities in JSON" do
+      get "/api/cities"
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json["cities"]).to eq([ "Bangalore", "Chennai", "London", "New York" ])
     end
   end
 end

--- a/spec/services/flight_data_service_spec.rb
+++ b/spec/services/flight_data_service_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe FlightDataService do
+  describe ".load_unique_cities" do
+    let(:data_path) { Rails.root.join("spec/testData/testData.txt") }
+
+    before do
+        Time.use_zone("Asia/Kolkata") do
+        allow(DynamicPricingService).to receive(:calculate_price).and_return(120.0)
+
+        today = Time.zone.today.strftime("%Y-%m-%d")
+        past_time = (1.hour.ago.in_time_zone).strftime("%I:%M %p")
+        future_time = (2.hours.from_now.in_time_zone).strftime("%I:%M %p")
+
+        FileUtils.mkdir_p(data_path.dirname)
+        File.write(data_path, <<~DATA)
+            F101,Bangalore,London,2025-07-12,03:23 PM,2025-07-13,09:23 AM,100,500,50,30,20,50,30,20
+            F102,Bangalore,New York,2025-07-04,03:23 PM,2025-07-12,09:23 PM,10,900,5,3,2,5,3,2
+            F103,Chennai,London,2025-07-05,03:23 PM,2025-07-12,09:23 PM,50,600,20,20,10,20,20,10
+        DATA
+        end
+    end
+
+    it "returns unique sorted cities from file" do
+      result = FlightDataService.load_unique_cities
+
+      expect(result).to eq(
+        [ "Bangalore", "Chennai", "London", "New York" ]
+      )
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces an API to expose the list of unique cities used in the CloudTrip backend. It includes:

#### New FlightDataService
- Adds FlightDataService.load_unique_cities to read cities from data.txt file.
- Extracts source and destination cities from each flight record.
- Returns a sorted, unique list of cities.

#### New API Endpoint
- Adds GET /api/cities route under Api::FlightsController.
- Returns JSON of new cities.

#### Specs
- Added specs for FlightDataService to verify file reading and city extraction.
- Added controller spec for /api/cities to ensure correct JSON structure and HTTP 200 response.

#### CORS
- Ensured CORS is configured to allow frontend requests.

