### PR TITLE
Implement Round-Trip Flight Booking Functionality

### DIFF
--- a/app/controllers/api/bookings_controller.rb
+++ b/app/controllers/api/bookings_controller.rb
@@ -31,6 +31,76 @@ module Api
       end
     end
 
+    def round_trip_booking
+      bookings = params[:bookings]
+
+      unless bookings.is_a?(Array) && bookings.size == 2
+        render json: { updated: false, error: "Both onward and return bookings must be provided" }, status: :bad_request and return
+      end
+
+      onward_validator = FlightBookingValidator.new(prepare_service_params(bookings[0]))
+      return_validator = FlightBookingValidator.new(prepare_service_params(bookings[1]))
+
+      unless onward_validator.valid?
+        return render json: { updated: false, error: "Onward booking failed: #{onward_validator.errors.last[:message]}" }, status: onward_validator.errors.last[:status]
+      end
+
+      unless return_validator.valid?
+        return render json: { updated: false, error: "Return booking failed: #{return_validator.errors.last[:message]}" }, status: return_validator.errors.last[:status]
+      end
+
+      return_result = nil
+      onward_result = nil
+
+      ActiveRecord::Base.transaction do
+        onward_result = FlightBookingService.new(
+          schedule: onward_validator.schedule,
+          seat: onward_validator.seat,
+          passengers: onward_validator.instance_variable_get(:@passengers)
+        ).book_flight
+
+        unless onward_result[:success]
+          render json: {
+            updated: false,
+            error: "Onward booking failed: #{onward_result[:message]}"
+          }, status: onward_result[:status] || :unprocessable_entity and return
+        end
+
+        return_result = FlightBookingService.new(
+          schedule: return_validator.schedule,
+          seat: return_validator.seat,
+          passengers: return_validator.instance_variable_get(:@passengers)
+        ).book_flight
+
+        unless return_result[:success]
+          raise ActiveRecord::Rollback
+        end
+
+        render json: {
+          updated: true,
+          message: "Round trip booking successful🎉",
+          onward: onward_result[:data],
+          return: return_result[:data]
+        }, status: :ok and return
+      end
+
+      if return_result && !return_result[:success]
+        render json: {
+          updated: false,
+          error: "Return booking failed: #{return_result[:message]}"
+        }, status: return_result[:status] || :unprocessable_entity
+      else
+        render json: {
+          updated: false,
+          error: "Return booking failed. Entire booking rolled back."
+        }, status: :unprocessable_entity
+      end
+    rescue => e
+      render json: { updated: false, error: "Booking failed: #{e.message}" }, status: :internal_server_error
+    end
+
+    private
+
     def extract_booking_params
       flight_params   = params[:flight] || {}
       flight_number   = flight_params[:flight_number]
@@ -43,6 +113,17 @@ module Api
       departure_time  = flight_params[:departure_time]
 
       [ flight_number, class_type, passengers, source, destination, departure_date, departure_time ]
+    end
+
+    def prepare_service_params(flight_data)
+      {
+        flight_number: flight_data[:flight_number],
+        class_type: flight_data[:class_type] || "economy",
+        passengers: (flight_data[:passengers].to_i <= 0 ? 1 : flight_data[:passengers].to_i),
+        source: flight_data[:source],
+        destination: flight_data[:destination],
+        date: flight_data[:departure_date]
+      }
     end
   end
 end

--- a/app/services/flight_booking_service.rb
+++ b/app/services/flight_booking_service.rb
@@ -13,8 +13,9 @@ class FlightBookingService
 
       @seat.update!(available_seats: @seat.available_seats - @passengers)
     end
+
     success("Booking successful", @seat)
-    rescue ActiveRecord::ActiveRecordError => e
+  rescue ActiveRecord::ActiveRecordError => e
     error("Booking failed: #{e.message}", 500)
   end
 

--- a/app/validators/flight_booking_validator.rb
+++ b/app/validators/flight_booking_validator.rb
@@ -24,22 +24,25 @@ class FlightBookingValidator
   private
 
   def fetch_flight
-     source_airport = Airport.find_by("LOWER(city) = ?", @source.downcase)
+    source_airport = Airport.find_by("LOWER(city) = ?", @source.downcase)
     destination_airport = Airport.find_by("LOWER(city) = ?", @destination.downcase)
 
     unless source_airport && destination_airport
         @errors << { message: "Source or destination airport not found", status: 404 }
         return nil
     end
+
     flight = Flight.find_by(
       flight_number: @flight_number,
       source: source_airport,
       destination: destination_airport
     )
+
     unless flight
       @errors << { message: "Flight not found", status: 404 }
       return nil
     end
+
     flight
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,6 @@ Rails.application.routes.draw do
     get "cities", to: "airports#cities"
     post "flights", to: "flights#search"
     post "book", to: "bookings#booking"
+    post "round_trip_booking", to: "bookings#round_trip_booking"
   end
 end

--- a/spec/requests/api/bookings_spec.rb
+++ b/spec/requests/api/bookings_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "Api::BookingsController", type: :request do
       expect(response).to have_http_status(:ok)
       json = response.parsed_body
       expect(json["updated"]).to eq(true)
-      expect(json["message"]).to eq("Booking successful") # assuming this is your service message
+      expect(json["message"]).to eq("Booking successful")
       expect(json["data"]).to be_present
     end
 
@@ -102,7 +102,6 @@ RSpec.describe "Api::BookingsController", type: :request do
     end
 
     it "returns 422 when booking service fails" do
-      # simulate failure inside the booking service
       allow_any_instance_of(FlightBookingService).to receive(:book_flight).and_return(
         { success: false, message: "Unexpected error while booking" }
       )
@@ -112,6 +111,151 @@ RSpec.describe "Api::BookingsController", type: :request do
       json = response.parsed_body
       expect(json["updated"]).to eq(false)
       expect(json["error"]).to eq("Unexpected error while booking")
+    end
+
+    it "defaults to 1 passenger in one-way booking if 0 is given" do
+      params = valid_params.deep_dup
+      params[:passengers] = 0
+      post "/api/book", params: params
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json["updated"]).to eq(true)
+    end
+  end
+
+  describe "POST /api/round_trip_booking" do
+    let(:return_flight) {
+      Flight.create!(
+        flight_number: "AI124",
+        source: destination_airport,
+        destination: source_airport,
+        departure_time: Time.zone.today.change(hour: 18),
+        duration_minutes: 120,
+        is_recurring: false,
+      )
+    }
+
+    let(:return_schedule_date) { schedule_date + 5 }
+
+    let(:return_schedule) {
+      return_flight.flight_schedules.create!(flight_date: return_schedule_date)
+    }
+
+    let!(:return_seat) {
+      FlightScheduleSeat.create!(
+        flight_schedule: return_schedule,
+        seat_class: seat_class,
+        available_seats: 10
+      )
+    }
+
+    let(:onward_booking) {
+      {
+        flight_number: flight.flight_number,
+        source: source_airport.city,
+        destination: destination_airport.city,
+        class_type: seat_class.name.downcase,
+        passengers: 2,
+        departure_date: schedule_date
+      }
+    }
+
+    let(:return_booking) {
+      {
+        flight_number: return_flight.flight_number,
+        source: destination_airport.city,
+        destination: source_airport.city,
+        class_type: seat_class.name.downcase,
+        passengers: 2,
+        departure_date: return_schedule_date
+      }
+    }
+
+    let(:valid_params) { { bookings: [onward_booking, return_booking] } }
+
+    it "books round trip successfully with valid data" do
+      post "/api/round_trip_booking", params: valid_params
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json["updated"]).to eq(true)
+      expect(json["message"]).to eq("Round trip booking successful🎉")
+      expect(json["onward"]).to be_present
+      expect(json["return"]).to be_present
+    end
+
+    it "fails when bookings param is not an array of two" do
+      post "/api/round_trip_booking", params: { bookings: [onward_booking] }
+      expect(response).to have_http_status(:bad_request)
+      json = JSON.parse(response.body)
+      expect(json["updated"]).to eq(false)
+      expect(json["error"]).to eq("Both onward and return bookings must be provided")
+    end
+
+    it "fails when onward schedule is missing" do
+      schedule.destroy
+      post "/api/round_trip_booking", params: valid_params
+      expect(response).to have_http_status(:not_found) 
+      json = JSON.parse(response.body)  
+      expect(json["updated"]).to eq(false)
+      expect(json["error"]).to start_with("Onward booking failed:")
+    end
+
+    it "fails and rolls back when return booking fails" do
+      return_seat.update!(available_seats: 0)
+      post "/api/round_trip_booking", params: valid_params
+      expect(response).to have_http_status(:conflict) 
+      json = JSON.parse(response.body)
+      expect(json["updated"]).to eq(false)
+      expect(json["error"]).to start_with("Return booking failed:")
+    end
+
+    it "handles unexpected errors gracefully" do
+      allow_any_instance_of(FlightBookingService).to receive(:book_flight).and_raise(StandardError.new("unexpected crash"))
+      post "/api/round_trip_booking", params: valid_params
+      expect(response).to have_http_status(:internal_server_error)
+      json = JSON.parse(response.body)
+      expect(json["updated"]).to eq(false)
+      expect(json["error"]).to eq("Booking failed: unexpected crash")
+    end
+
+    it "handles return booking failure after transaction block" do
+      allow_any_instance_of(FlightBookingService).to receive(:book_flight).and_wrap_original do |original, *args|
+        @calls ||= 0
+        @calls += 1
+        if @calls == 1
+          { success: true, message: "Onward booked", data: {} }
+        else
+          { success: false, message: "Return failed", status: 422 }
+        end
+      end
+
+      post "/api/round_trip_booking", params: valid_params
+      expect(response).to have_http_status(:unprocessable_entity)
+      json = response.parsed_body
+      expect(json["updated"]).to eq(false)
+      expect(json["error"]).to eq("Return booking failed: Return failed")
+    end
+
+    it "fails and returns from transaction if onward booking fails" do
+      allow_any_instance_of(FlightBookingService).to receive(:book_flight).and_return(
+        { success: false, message: "Onward failed", status: 422 }
+      )
+
+      post "/api/round_trip_booking", params: valid_params
+      expect(response).to have_http_status(:unprocessable_entity)
+      json = response.parsed_body
+      expect(json["updated"]).to eq(false)
+      expect(json["error"]).to start_with("Onward booking failed:")
+    end
+
+    it "defaults to 1 passenger if 0 is given" do
+      zero_passenger_booking = onward_booking.deep_dup
+      zero_passenger_booking[:passengers] = 0
+
+      post "/api/round_trip_booking", params: { bookings: [zero_passenger_booking, return_booking] }
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json["updated"]).to eq(true)
     end
   end
 end

--- a/spec/requests/api/bookings_spec.rb
+++ b/spec/requests/api/bookings_spec.rb
@@ -171,12 +171,12 @@ RSpec.describe "Api::BookingsController", type: :request do
       }
     }
 
-    let(:valid_params) { { bookings: [onward_booking, return_booking] } }
+    let(:valid_params) { { bookings: [ onward_booking, return_booking ] } }
 
     it "books round trip successfully with valid data" do
       post "/api/round_trip_booking", params: valid_params
       expect(response).to have_http_status(:ok)
-      json = JSON.parse(response.body)
+      json = response.parsed_body
       expect(json["updated"]).to eq(true)
       expect(json["message"]).to eq("Round trip booking successful🎉")
       expect(json["onward"]).to be_present
@@ -184,9 +184,9 @@ RSpec.describe "Api::BookingsController", type: :request do
     end
 
     it "fails when bookings param is not an array of two" do
-      post "/api/round_trip_booking", params: { bookings: [onward_booking] }
+      post "/api/round_trip_booking", params: { bookings: [ onward_booking ] }
       expect(response).to have_http_status(:bad_request)
-      json = JSON.parse(response.body)
+      json = response.parsed_body
       expect(json["updated"]).to eq(false)
       expect(json["error"]).to eq("Both onward and return bookings must be provided")
     end
@@ -194,8 +194,8 @@ RSpec.describe "Api::BookingsController", type: :request do
     it "fails when onward schedule is missing" do
       schedule.destroy
       post "/api/round_trip_booking", params: valid_params
-      expect(response).to have_http_status(:not_found) 
-      json = JSON.parse(response.body)  
+      expect(response).to have_http_status(:not_found)
+      json = response.parsed_body
       expect(json["updated"]).to eq(false)
       expect(json["error"]).to start_with("Onward booking failed:")
     end
@@ -203,8 +203,8 @@ RSpec.describe "Api::BookingsController", type: :request do
     it "fails and rolls back when return booking fails" do
       return_seat.update!(available_seats: 0)
       post "/api/round_trip_booking", params: valid_params
-      expect(response).to have_http_status(:conflict) 
-      json = JSON.parse(response.body)
+      expect(response).to have_http_status(:conflict)
+      json = response.parsed_body
       expect(json["updated"]).to eq(false)
       expect(json["error"]).to start_with("Return booking failed:")
     end
@@ -213,7 +213,7 @@ RSpec.describe "Api::BookingsController", type: :request do
       allow_any_instance_of(FlightBookingService).to receive(:book_flight).and_raise(StandardError.new("unexpected crash"))
       post "/api/round_trip_booking", params: valid_params
       expect(response).to have_http_status(:internal_server_error)
-      json = JSON.parse(response.body)
+      json = response.parsed_body
       expect(json["updated"]).to eq(false)
       expect(json["error"]).to eq("Booking failed: unexpected crash")
     end
@@ -252,7 +252,7 @@ RSpec.describe "Api::BookingsController", type: :request do
       zero_passenger_booking = onward_booking.deep_dup
       zero_passenger_booking[:passengers] = 0
 
-      post "/api/round_trip_booking", params: { bookings: [zero_passenger_booking, return_booking] }
+      post "/api/round_trip_booking", params: { bookings: [ zero_passenger_booking, return_booking ] }
       expect(response).to have_http_status(:ok)
       json = response.parsed_body
       expect(json["updated"]).to eq(true)


### PR DESCRIPTION
This PR introduces full support for round-trip flight booking along with using existing validator.


- Adds a new `/api/round_trip_booking` endpoint to handle both onward and return journey bookings in a single transaction.
- Ensures atomicity: If the return booking fails, the onward booking is rolled back with appropriate error messaging.

### Test Coverage Enhancements

- Adds request specs for round-trip booking, including:
  - Success scenario
  - Failure rollback for return booking

Thank you!! 😄